### PR TITLE
Fixed compute token length

### DIFF
--- a/src/compute_lengths.py
+++ b/src/compute_lengths.py
@@ -15,5 +15,5 @@ if __name__ == '__main__':
     max_input_length = -1
     max_target_length = -1
 
-    dataset_processor = DatasetProcessor(dataset_name, task, task_format, task_mode, max_input_length, max_target_length)
+    dataset_processor = DatasetProcessor(dataset_name, task, task_format, task_mode, model_name, max_input_length, max_target_length)
     dataset_processor.load_and_preprocess_data()

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -78,6 +78,7 @@ class DatasetProcessor:
         processed_dataset = dataset.map(preprocess_function, remove_columns=column_names, batched=True)
         if self.max_input_length == -1 or self.max_target_length == -1:
             self.compute_token_length(processed_dataset)
+            return
         tokenized_dataset = processed_dataset.map(self.tokenize_function, batched=True)
         return tokenized_dataset
 


### PR DESCRIPTION
- The **tokenizer_name** parameter was missing in the compute_token_lengths script. Added it. 
- After computing the token lengths, it went on to tokenize and due to missing min/max length, it received an error. Added a return such that after computing, it exits without tokenization. 