### PR TITLE
Implement Adam Optimizer 

### DIFF
--- a/experiments/conf/default.yaml
+++ b/experiments/conf/default.yaml
@@ -10,7 +10,7 @@ training_params:
   remove_unused_columns: False
   push_to_hub: False
   report_to: wandb
-  optimizer_params:
-    optimizer_type: adafactor # adafactor or adam
-    scheduler: False # 'linear' for adam
+optimizer_params:
+  optimizer_type: adafactor # adafactor or adam
+  scheduler: False # 'linear' for adam
 dataset_loc: ""

--- a/experiments/finetune.py
+++ b/experiments/finetune.py
@@ -31,6 +31,9 @@ def main(cfg: DictConfig):
     logger.info(f'Max target length: {max_target_length}')
     training_params = cfg.training_params
     logger.info(f'Training parameters: {training_params}')
+    optimizer_params = cfg.optimizer_params
+    logger.info(f'Optimizer parameters: {optimizer_params}')
+
     dataset_location = cfg.dataset_loc
     if "num_labels" in cfg.keys():
         num_labels = cfg.num_labels
@@ -83,10 +86,10 @@ def main(cfg: DictConfig):
 
     if task_format == 'conditional_generation':
         logger.info("******Conditional Generation Mode******")
-        model_trainer = TrainerForConditionalGeneration(model_name, task, training_params, model_save_path, max_input_length, max_target_length, postprocess_fn)
+        model_trainer = TrainerForConditionalGeneration(model_name, task, training_params, optimizer_params, model_save_path, max_input_length, max_target_length, postprocess_fn)
     elif task_format == 'classification':
         logger.info("******Classification Mode******")
-        model_trainer = TrainerForClassification(model_name, task, training_params, model_save_path, num_labels)
+        model_trainer = TrainerForClassification(model_name, task, training_params, optimizer_params, model_save_path, num_labels)
 
     trainer, model = model_trainer.train_and_evaluate(train_dataset, eval_dataset, test_dataset)
 

--- a/turkish_lm_tuner/trainer.py
+++ b/turkish_lm_tuner/trainer.py
@@ -27,9 +27,9 @@ stream_handler.setFormatter(formatter)
 logger.addHandler(stream_handler)
 
 class BaseModelTrainer:
-    def __init__(self, model_name, training_params=None):
+    def __init__(self, model_name, training_params=None, optimizer_params=None):
         self.model_name = model_name
-        self.optimizer_params = training_params['optimizer_params'] if training_params['optimizer_params'] is not None else {'optimizer_type': 'adafactor', 'scheduler': False}
+        self.optimizer_params = optimizer_params if optimizer_params is not None else {'optimizer_type': 'adafactor', 'scheduler': False}
         self.training_params = training_params
         self.tokenizer = AutoTokenizer.from_pretrained(model_name)
 
@@ -98,8 +98,8 @@ class BaseModelTrainer:
 
 
 class TrainerForConditionalGeneration(BaseModelTrainer):
-    def __init__(self, model_name, task, training_params, model_save_path, max_input_length, max_target_length, postprocess_fn):
-        super().__init__(model_name, training_params)
+    def __init__(self, model_name, task, training_params, optimizer_params, model_save_path, max_input_length, max_target_length, postprocess_fn):
+        super().__init__(model_name, training_params, optimizer_params)
         self.max_input_length = max_input_length
         self.max_target_length = max_target_length
         self.evaluator = EvaluatorForConditionalGeneration(model_save_path, model_name, task, max_input_length, max_target_length, training_params, postprocess_fn=postprocess_fn)
@@ -148,8 +148,8 @@ class TrainerForConditionalGeneration(BaseModelTrainer):
 
 
 class TrainerForClassification(BaseModelTrainer):
-    def __init__(self, model_name, task, training_params, model_save_path, num_labels):
-        super().__init__(model_name, training_params)
+    def __init__(self, model_name, task, training_params, optimizer_params, model_save_path, num_labels):
+        super().__init__(model_name, training_params, optimizer_params)
         self.num_labels = num_labels
         self.evaluator = EvaluatorForClassification(model_save_path, model_name, task, training_params)
 


### PR DESCRIPTION
This pull request introduces changes to the optimizer and linear scheduler configurations in the `trainer.py` and `finetune.py` 

The current implementation supports Adafactor optimizer, with optional scheduler and the default transformers trainer optimizer, AdamW with a learning rate of 5e-5 and a linear scheduler.

Usage instructions:

To employ Adafactor with a scheduler, configure as follows:
```yaml
optimizer_params:
  optimizer_type: adafactor  # Options: adafactor or adam
  scheduler: True
```
To use Adafactor without a scheduler, configure as follows:
```yaml
optimizer_params:
  optimizer_type: adafactor  # Options: adafactor or adam
  scheduler: False
```
For default parameters (utilizing AdamW and a linear scheduler), any setting other than `adafactor` is required:
```yaml
optimizer_params:
  optimizer_type: adamw
  scheduler: linear
```