### PR TITLE
Fixes in MLSUM and TRNews dataset

### DIFF
--- a/turkish_lm_tuner/tr_datasets.py
+++ b/turkish_lm_tuner/tr_datasets.py
@@ -46,7 +46,7 @@ class TRNewsDataset(BaseDataset):
     DATASET_INFO = "batubayk/TR-News"
     
     def preprocess_data(self, examples):
-        return {"input_text": examples["content"], "target_text": examples["summary"]}
+        return {"input_text": examples["content"], "target_text": examples["abstract"]}
 
 class MLSumDataset(BaseDataset):
     DATASET_NAME = "mlsum"


### PR DESCRIPTION
Unfortunately, a bug in the MLSUM and TRNews dataset implementations resulted in one functioning as a summarization dataset and the other as a title generation one :( This pull request addresses the issue by implementing separate summarization and title generation datasets for each dataset.